### PR TITLE
Add capability to add attachments to mail campaigns

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Here is an example how you could proceed with creating and issuing a newsletter:
 
 	# locate the mailing list we'll be sending to
 	list = Smailer::Models::MailingList.first
-	
+
 	# create a corresponding mail campaign
 	campaign_params = {
 		:from      => 'noreply@example.org',
@@ -66,7 +66,10 @@ Here is an example how you could proceed with creating and issuing a newsletter:
 	campaign = Smailer::Models::MailCampaign.new campaign_params
 	campaign.add_unsubscribe_method :all
 	campaign.save!
-	
+
+	# Add attachments
+	campaign.add_attachment 'attachment.pdf', 'url_or_file_path_to_attachment'
+
 	# enqueue mails to be sent out
 	subscribers = %w[
 		subscriber@domain.com
@@ -80,7 +83,7 @@ Here is an example how you could proceed with creating and issuing a newsletter:
 
 ### Managing unsubscriptions
 
-Among the few unsubscription methods supported, probably the most widely used one is unsubscription via a unsubscribe link in the email. 
+Among the few unsubscription methods supported, probably the most widely used one is unsubscription via a unsubscribe link in the email.
 
 In order to help you with implementing it, Smailer provides you with some interpolations you can use in the email's body:
 
@@ -145,7 +148,7 @@ Suppose you manage your site's newsletter subscriptions via a `Subscription` mod
 	    :subscribed_checker => subscribed_checker,
 	  }) do |unsubscribe_details|
 	    subscription = Subscription.confirmed.subscribed.where(:email => unsubscribe_details[:recipient]).first
-	
+
 	    if subscription
 	      subscription.subscribed = false
 	      subscription.unsubscribe_reason = 'Automatic, due to bounces'

--- a/lib/generators/smailer/templates/migration.rb.erb
+++ b/lib/generators/smailer/templates/migration.rb.erb
@@ -37,6 +37,15 @@ class CreateSmailerTables < ActiveRecord::Migration
     add_index "queued_mails", ["locked", "retries", "id"], :name => "index_queued_mails_on_locked_retries_and_id"
     add_index "queued_mails", ["locked", "locked_at"], :name => "index_queued_mails_on_locked_and_locked_at"
 
+    create_table "mail_campaign_attachments", :force => true do |t|
+      t.integer "mail_campaign_id", :null => false
+      t.string "filename", :null => false
+      t.string "path", :limit => 2048
+      t.datetime "created_at"
+      t.datetime "updated_at"
+    end
+    add_index "mail_campaign_attachments", "mail_campaign_id"
+
     create_table "finished_mails", :force => true do |t|
       t.integer  "mail_campaign_id"
       t.string   "from"
@@ -79,23 +88,11 @@ class CreateSmailerTables < ActiveRecord::Migration
 
   def self.down
     drop_table :smailer_properties
-
-    remove_index :mail_keys, :name => "index_mail_keys_on_email"
-    remove_index :mail_keys, :name => "index_mail_keys_on_email"
     drop_table :mail_keys
-
-    remove_index :finished_mails, :name => "index_finished_mails_on_key"
-    remove_index :finished_mails, :name => "index_finished_mails_on_mail_campain_id_and_status"
-    remove_index :finished_mails, :name => "index_finished_mails_on_to_and_mail_campaign_id"
     drop_table :finished_mails
-
-    remove_index :queued_mails, :name => "index_queued_mails_on_mail_campain_id_and_to"
-    remove_index :queued_mails, :name => "index_queued_mails_on_retries"
     drop_table :queued_mails
-
-    remove_index :mail_campaigns, :name => "index_mail_campaigns_on_mailing_list_id"
+    drop_table :mail_campaign_attachments
     drop_table :mail_campaigns
-
     drop_table :mailing_lists
   end
 end

--- a/lib/smailer/models.rb
+++ b/lib/smailer/models.rb
@@ -2,6 +2,7 @@ module Smailer
   module Models
     autoload :MailingList,    'smailer/models/mailing_list'
     autoload :MailCampaign,   'smailer/models/mail_campaign'
+    autoload :MailCampaignAttachment, 'smailer/models/mail_campaign_attachment'
     autoload :MailKey,        'smailer/models/mail_key'
     autoload :QueuedMail,     'smailer/models/queued_mail'
     autoload :FinishedMail,   'smailer/models/finished_mail'

--- a/lib/smailer/models/mail_campaign.rb
+++ b/lib/smailer/models/mail_campaign.rb
@@ -10,6 +10,8 @@ module Smailer
       belongs_to :mailing_list
       has_many :queued_mails, :dependent => :destroy
       has_many :finished_mails, :dependent => :destroy
+      has_many :attachments,
+               :class_name => '::Smailer::Models::MailCampaignAttachment'
 
       validates_presence_of :mailing_list_id, :from
       validates_numericality_of :mailing_list_id, :unsubscribe_methods, :only_integer => true, :allow_nil => true
@@ -46,6 +48,10 @@ module Smailer
       def hit_rate
         return nil if sent_mails_count == 0
         opened_mails_count.to_f / sent_mails_count
+      end
+
+      def add_attachment(filename, path)
+        self.attachments.create!(:filename => filename, :path => path)
       end
 
       def self.unsubscribe_methods

--- a/lib/smailer/models/mail_campaign_attachment.rb
+++ b/lib/smailer/models/mail_campaign_attachment.rb
@@ -1,0 +1,19 @@
+require 'open-uri'
+
+module Smailer
+  module Models
+    class MailCampaignAttachment < ActiveRecord::Base
+
+      belongs_to :mail_campaign
+      validates_presence_of :mail_campaign_id
+      validates_numericality_of :mail_campaign_id
+      validates_presence_of :path
+      validates_presence_of :filename
+
+      def body
+        open(self.path).read
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This adds the `add_attachment` method to `MailCampaign`. It's pretty straightforward; I tested it with Rails 4 and everything seems to work smoothly. The Mail gem hasn't changed in a good long while so I don't foresee any major issues with it.

One other thing I did as part of this commit was remove all the calls to `drop_index` in the migration template; there is [no need](http://stackoverflow.com/questions/887590/does-dropping-a-table-in-mysql-also-drop-the-indexes no need) to do so explicitly.
