### PR TITLE
Fixes a migration generator warning:

### DIFF
--- a/lib/generators/smailer/migration_generator.rb
+++ b/lib/generators/smailer/migration_generator.rb
@@ -1,4 +1,5 @@
 require "rails/generators/active_record"
+require_relative '../../smailer'
 
 module Smailer
   class MigrationGenerator < Rails::Generators::Base

--- a/lib/generators/smailer/migration_generator.rb
+++ b/lib/generators/smailer/migration_generator.rb
@@ -1,5 +1,5 @@
 require "rails/generators/active_record"
-require_relative '../../smailer'
+require 'smailer'
 
 module Smailer
   class MigrationGenerator < Rails::Generators::Base

--- a/lib/smailer/version.rb
+++ b/lib/smailer/version.rb
@@ -1,7 +1,7 @@
 module Smailer
   MAJOR = 0
   MINOR = 7
-  PATCH = 5
+  PATCH = 6
 
   VERSION = [MAJOR, MINOR, PATCH].join('.')
 end


### PR DESCRIPTION
The message was:

[WARNING] Could not load generator "generators/smailer/migration_generator". Error: uninitialized constant Smailer::Compatibility.

I just included the smailer module and increment the version to 0.7.6.