### PR TITLE
Fix the behaviour of QueuedMail.new(to: …, from: …, mail_campaign: …)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ You can send one-off emails that each have a different mail template:
     # Changing the campaign now won't change anything in the one-off queued mails.
 
     # Sending two mails to the same person for a single campaign:
-    campaign.queued_mails.create! :to => 'subscriber@domain.com', :body_html => 'second custom body', :body_text => 'second custom body', require_uniqueness => false
+    campaign.queued_mails.create! :to => 'subscriber@domain.com', :body_html => 'second custom body', :body_text => 'second custom body', :require_uniqueness => false
 
 You can change the `from`, `subject`, `body_html`, `body_text` and you can also call `add_attachment`. For more info check [Smailer::Models::QueuedMail](lib/smailer/models/queued_mail.rb).
 

--- a/spec/features/sending_oneoff_emails_spec.rb
+++ b/spec/features/sending_oneoff_emails_spec.rb
@@ -17,7 +17,7 @@ describe 'Sending one-off emails' do
       # if you change the campaign now it won't change the one-off queued_mails
 
       # sending two mails to the same person
-      campaign.queued_mails.create! :to => 'subscriber@domain.com', :body_html => '<h1>second custom body</h1>', :body_text => 'second custom body', require_uniqueness => false
+      campaign.queued_mails.create! :to => 'subscriber@domain.com', :body_html => '<h1>second custom body</h1>', :body_text => 'second custom body', :require_uniqueness => false
 
       expect(Smailer::Models::MailCampaign.count).to eq(1)
       expect(Smailer::Models::MailTemplate.count).to eq(3) # 1 for the campaign and 2 for the one-off emails
@@ -33,8 +33,8 @@ describe 'Sending one-off emails' do
 
       second_mail = campaign.queued_mails.last
 
-      expect(second_mail.from).to      eq(campaign_params.from)
-      expect(second_mail.subject).to   eq(campaign_params.subject)
+      expect(second_mail.from).to      eq(campaign.from)
+      expect(second_mail.subject).to   eq(campaign.subject)
       expect(second_mail.body_html).to eq('<h1>second custom body</h1>')
       expect(second_mail.body_text).to eq('second custom body')
     end

--- a/spec/models/queued_mail_spec.rb
+++ b/spec/models/queued_mail_spec.rb
@@ -1,6 +1,27 @@
 require 'spec_helper'
 
 describe Smailer::Models::QueuedMail do
+  describe '.new' do
+    it 'will fill the mail_template from the mail_campaign as expected' do
+      mail_campaign = FactoryGirl.create(:mail_campaign, :subject => 'Campaign subject', :from => 'from@campaign.com')
+
+      queued_mail = Smailer::Models::QueuedMail.new(
+        :to => 'someone@world.com',
+        :body_html => 'Custom html body',
+        :body_text => 'Custom text body',
+        :mail_campaign => mail_campaign
+      )
+
+      queued_mail.valid?
+      expect(queued_mail.errors).to be_blank
+
+      expect(queued_mail.from).to      eq('from@campaign.com')
+      expect(queued_mail.subject).to   eq('Campaign subject')
+      expect(queued_mail.body_html).to eq('Custom html body')
+      expect(queued_mail.body_text).to eq('Custom text body')
+    end
+  end
+
   describe '#save' do
     it 'could be made only with mail_campaign and to (recipient)' do
       mail_campaign = FactoryGirl.create(:mail_campaign)


### PR DESCRIPTION
QueuedMail#mail_campaign= and QueuedMail#mail_campaign_id= will update
the QueuedMail#mail_template (if it is present) by filling the nil
fields with the ones from the mail_campaign.mail_template

The attachments will be copied if the one in the QueuedMail are blank.